### PR TITLE
Fix missing data in output for conflicting NPM peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ Example:
 ## Run the tool
 
 E.g. using gradle:
-`gradlew bootRun --args="input.json"`
+`gradlew bootRun --args="./input.json"`

--- a/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmDependency.kt
+++ b/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmDependency.kt
@@ -1,6 +1,7 @@
 package com.vladonemo.tools.dependencycollector.input.npm
 
 data class NpmDependency(val version: String = "",
+                         val required: NpmRequiredDependency? = null,
                          val from: String = "",
                          var resolved: String = "",
                          var peerMissing: Boolean = false

--- a/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmParser.kt
+++ b/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmParser.kt
@@ -11,8 +11,8 @@ class NpmParser : Parser {
                 ?.map {
                     Dependency().apply {
                         name = it.key
-                        version = it.value.version
-                        link = it.value.resolved
+                        version = it.value.required?.version ?: it.value.version
+                        link = it.value.required?._resolved ?: it.value.resolved
                     }
                 }
     }

--- a/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmRequiredDependency.kt
+++ b/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmRequiredDependency.kt
@@ -1,0 +1,5 @@
+package com.vladonemo.tools.dependencycollector.input.npm
+
+data class NpmRequiredDependency(val version: String = "",
+                                 val _resolved: String = ""
+)


### PR DESCRIPTION
In case project's `package.json` file includes dependencies which are required as peer dependencies, the output of `npm ls --json --parseable --depth=0 --prod=true` command has the version and package link inside `required` field and not as top-level fields.

Below is the example:
``` 
"rxjs": {
      "required": {
           ...
           "_resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
           "version": "6.5.5",
           ...
      }
}
```

The generated output then has version number and package link missing.
![obrázok](https://user-images.githubusercontent.com/24683239/112995711-c8b89400-916b-11eb-968a-41c83e21410e.png)

This PR fixes the issue, the output then looks like this:
![obrázok](https://user-images.githubusercontent.com/24683239/112995881-f998c900-916b-11eb-983f-629222b03ab6.png)

Unit tests will come later in a separate pull request.

---

Besides, this PR updates _README.md_ withthe command for running the tool to include the parent directory of the input file within the argument specification. If it is missing and only the file name is used, running the tool throws the following exception:
```
java.lang.IllegalStateException: Failed to execute CommandLineRunner
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:787) ~[spring-boot-2.2.1.RELEASE.jar:2.2.1.RELEASE]
	at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:768) ~[spring-boot-2.2.1.RELEASE.jar:2.2.1.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:322) ~[spring-boot-2.2.1.RELEASE.jar:2.2.1.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226) ~[spring-boot-2.2.1.RELEASE.jar:2.2.1.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1215) ~[spring-boot-2.2.1.RELEASE.jar:2.2.1.RELEASE]
	at com.vladonemo.tools.dependencycollector.DependencyCollectorApplicationKt.main(DependencyCollectorApplication.kt:66) ~[main/:na]
Caused by: java.lang.IllegalStateException: parent must not be null
	at com.vladonemo.tools.dependencycollector.DependencyCollectorApplication.run(DependencyCollectorApplication.kt:44) ~[main/:na]
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:784) ~[spring-boot-2.2.1.RELEASE.jar:2.2.1.RELEASE]
	... 5 common frames omitted
```