### PR TITLE
Add support for nested NPM dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Generate the DOT file of your project:
   - to get production dependencies: `npm ls --json --parseable --depth=0 --prod=true > npm.json`
   - to get development dependencies: `npm ls --json --parseable --depth=0 --dev=true > npm-dev.json`
 
+In case you want to include nested dependencies in the list,
+omit `--depth=0` argument from `npm ls` command
+
 
 ## Define json configuration
 

--- a/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/Dependency.kt
+++ b/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/Dependency.kt
@@ -4,6 +4,8 @@ open class Dependency {
     var name: String = ""
     var version: String = ""
     var link: String = ""
+    var dependencies: List<Dependency>? = null
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmDependency.kt
+++ b/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmDependency.kt
@@ -4,5 +4,6 @@ data class NpmDependency(val version: String = "",
                          val required: NpmRequiredDependency? = null,
                          val from: String = "",
                          var resolved: String = "",
-                         var peerMissing: Boolean = false
+                         var peerMissing: Boolean = false,
+                         var dependencies: Map<String, NpmDependency>? = null
 )

--- a/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmParser.kt
+++ b/src/main/kotlin/com/vladonemo/tools/dependencycollector/input/npm/NpmParser.kt
@@ -7,13 +7,17 @@ import java.io.File
 
 class NpmParser : Parser {
     override fun parse(file: File): List<Dependency>? {
-        return Klaxon().parse<NpmLs>(file)?.dependencies
-                ?.map {
-                    Dependency().apply {
-                        name = it.key
-                        version = it.value.required?.version ?: it.value.version
-                        link = it.value.required?._resolved ?: it.value.resolved
-                    }
-                }
+        return parseDependencies(Klaxon().parse<NpmLs>(file)?.dependencies)
+    }
+
+    private fun parseDependencies(dependencyMap: Map<String, NpmDependency>?): List<Dependency>? {
+        return dependencyMap?.map {
+            Dependency().apply {
+                name = it.key
+                version = it.value.required?.version ?: it.value.version
+                link = it.value.required?._resolved ?: it.value.resolved
+                dependencies = parseDependencies(it.value.dependencies)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/vladonemo/tools/dependencycollector/output/markdown/MarkdownWriter.kt
+++ b/src/main/kotlin/com/vladonemo/tools/dependencycollector/output/markdown/MarkdownWriter.kt
@@ -1,6 +1,7 @@
 package com.vladonemo.tools.dependencycollector.output.markdown
 
 import com.vladonemo.tools.dependencycollector.Group
+import com.vladonemo.tools.dependencycollector.input.Dependency
 import com.vladonemo.tools.dependencycollector.output.OutputWriter
 import java.io.File
 import java.io.PrintWriter
@@ -12,8 +13,29 @@ class MarkdownWriter(file: File): OutputWriter(file) {
             writer.println()
             writer.println("|Name|Version|Link|")
             writer.println("|---|---|---|")
-            it.deps.forEach { dep -> writer.println("|${dep.name}|${dep.version}|${dep.link}|") }
+            it.deps.forEach { dep ->
+                run {
+                    writer.println("|${dep.name}|${dep.version}|${dep.link}|")
+                    writeInnerDependency(writer, dep)
+                }
+            }
             writer.println()
         }
+    }
+
+    private fun writeInnerDependency(writer: PrintWriter, dependency: Dependency, depth: Int = 1) {
+        dependency.dependencies?.forEach { dep ->
+            run {
+                writer.println("|${generateTabs(depth)}└─ ${dep.name}|${dep.version}|${dep.link}|")
+                writeInnerDependency(writer, dep, depth + 1)
+            }
+        }
+    }
+
+    private fun generateTabs(depth: Int): String {
+        var output = ""
+        repeat(depth) { output += "&emsp;"; }
+
+        return output
     }
 }


### PR DESCRIPTION
This PR enables support for nested dependency list making hierarchy of dependencies based on exported `JSON` file from `npm ls` command.

An example:
![image](https://user-images.githubusercontent.com/6184484/128494777-c29011d1-1dd9-406b-8a87-f6e09a5bb4af.png)